### PR TITLE
Fixes to be able to add rows to empty tables.

### DIFF
--- a/src/Forms/FormHandler.php
+++ b/src/Forms/FormHandler.php
@@ -1556,7 +1556,7 @@ class FormHandler
                         $form_action = "ask-add";
                     }
                     // CHECK IF THIS IS A SPLITABLE FIELD LIKE 012-014 OR 15,16,17
-                    if (in_array($this->FG_SPLITABLE_FIELDS, $fields_name) && !str_starts_with($processed[$fields_name], '_')) {
+                    if (in_array($fields_name, $this->FG_SPLITABLE_FIELDS) && !str_starts_with($processed[$fields_name], '_')) {
                         $value = $processed[$fields_name];
                         $items = explode(",", $value);
                         foreach ($items as $item) {

--- a/src/Forms/ViewForm.php
+++ b/src/Forms/ViewForm.php
@@ -40,10 +40,6 @@ class ViewForm
         $current_page = $this->current_page;
         $popup_select = $this->popup_select;
 
-        if (empty($list)) {
-            return "<div class='row pb-3 justify-content-center'><div class='col-8'>$form->CV_NO_FIELDS</div></div>";
-        }
-
         $origlist = [];
         $hasActionButtons = (
             $form->FG_ENABLE_DELETE_BUTTON || $form->FG_ENABLE_INFO_BUTTON || $form->FG_ENABLE_EDIT_BUTTON || $form->FG_OTHER_BUTTON1
@@ -53,6 +49,12 @@ class ViewForm
         ob_start();
         require(__DIR__ . "/../../templates/ViewHandler.inc.php");
 
-        return ob_get_clean() ?: "Template error!";
+        $output = ob_get_clean() ?: "Template error!";
+
+        if (empty($list)) {
+            $output .=  "<div class='row pb-3 justify-content-center'><div class='col-8'>$form->CV_NO_FIELDS</div></div>";
+        }
+
+        return $output;
     }
 }

--- a/templates/AddForm.inc.php
+++ b/templates/AddForm.inc.php
@@ -33,7 +33,7 @@ use A2billing\Table;
     </div>
     <?php endif ?>
 
-    <?php if (count($row["custom_query"]) === 0): ?>
+    <?php if (count($row["custom_query"] ?? []) === 0): ?>
     <div class="row mb-3">
         <label for="<?= $row["name"] ?>" class="col-3 col-form-label">
             <?= $row["label"] ?>

--- a/templates/ViewHandler.inc.php
+++ b/templates/ViewHandler.inc.php
@@ -19,7 +19,7 @@ $origlist = [];
 
 <?php if (($form -> FG_FILTER_ENABLE || $form -> FG_FILTER2_ENABLE) || ($popup_select < 1 && ($form->FG_LIST_ADDING_BUTTON1 || $form->FG_LIST_ADDING_BUTTON2))): ?>
 <div class="row pb-3 align-items-end">
-    <?php if ($form -> FG_FILTER_ENABLE || $form -> FG_FILTER2_ENABLE): ?>
+    <?php if ($form->FG_LIST_VIEW_ROW_COUNT > 0 && ($form -> FG_FILTER_ENABLE || $form -> FG_FILTER2_ENABLE)): ?>
     <form name="theFormFilter" action="" class="col">
         <input type="hidden" name="popup_select" value="<?= $processed['popup_select'] ?>"/>
         <input type="hidden" name="popup_formname" value="<?= $processed['popup_formname'] ?>"/>
@@ -91,6 +91,7 @@ $origlist = [];
 </div>
 <?php endif ?>
 
+<?php if ($form->FG_LIST_VIEW_ROW_COUNT > 0): ?>
 <div class="row pb-3">
     <div class="col table-responsive">
         <table class="table table-bordered table-striped table-hover caption-top <?php if ($popup_select): ?>table-sm<?php endif ?>">
@@ -342,6 +343,7 @@ $origlist = [];
     </div>
     <?php endif ?>
 </div>
+<?php endif ?>
 
 <script>
 $(function() {


### PR DESCRIPTION
In Web UI sections were tables are presented, if the table is empty no `Add` button is presented, so it's impossible to add elements to that table. This PR fixes that (tested in section `Admins` -> `Access Control`).