### PR TITLE
fix: accept 0 as a valid value for select fields in perform_add()

### DIFF
--- a/src/Forms/FormHandler.php
+++ b/src/Forms/FormHandler.php
@@ -1495,37 +1495,46 @@ class FormHandler
         foreach ($this->FG_EDIT_FORM_ELEMENTS as &$row) {
             $field = $row["name"] ?? "";
             $attr = $row["attributes"] ?? [];
-            if (empty($field) || array_key_exists("disabled", $attr)) {
+            if (empty($field) || array_key_exists("disabled", $attr) || !array_key_exists($field, $processed)) {
                 continue;
             }
 
-            if (array_key_exists("multiple", $attr) && is_array($processed[$field])) {
-                $values[$field] = (int)array_sum($processed[$field]);
+            $value = $processed[$field];
+            $check_empty = $row["check_empty"] ?? "";
+
+            if (array_key_exists("multiple", $attr) && is_array($value)) {
+                $values[$field] = (int)array_sum($value);
             }
+
             if (!empty($row["validator"])) {
-                if ($processed[$field] === "" && str_starts_with($row["check_empty"] ?? "", "NO")) {
+                $result = call_user_func($row["validator"], $value);
+                $row["validation_err"] = $result;
+                if ($result !== true) {
+                    $this->all_fields_valid = false;
+                    $form_action = "ask-add";
+                    continue;
+                }
+            } elseif ($value === "") {
+                if ($check_empty === "NO-NULL") {
+                    $value = null;
+                } elseif ($check_empty === "NO") {
                     $row["validation_err"] = true;
-                } else {
-                    $result = call_user_func($row["validator"], $processed[$field]);
-                    $row["validation_err"] = $result;
-                    if ($result !== true) {
-                        $this->all_fields_valid = false;
-                        $form_action = "ask-add";
-                        continue;
-                    }
+                    $this->all_fields_valid = false;
+                    $form_action = "ask-add";
+                    continue;
                 }
             }
+
             // CHECK IF THIS IS A SPLITABLE FIELD LIKE 012-014 OR 15,16,17
             if (in_array($field, $this->FG_SPLITABLE_FIELDS)) {
-                $value = $processed[$field];
                 if (empty($value) || str_starts_with($value, "_")) {
                     // dialprefix can be a range *or* an Asterisk-style extension pattern starting with _
                     continue;
                 }
                 $arr_value_to_import[$field] = $this->split_ranges($value);
                 $values[$field] = "%check_array%";
-            } elseif ((isset($processed[$field]) && $processed[$field] !== "") && $row["type"] !== "CAPTCHAIMAGE") {
-                $values[$field] ??= $processed[$field];
+            } elseif ($row["type"] !== "CAPTCHAIMAGE") {
+                $values[$field] ??= $value;
             }
         } // endforeach with reference
         unset ($row);

--- a/src/Forms/FormHandler.php
+++ b/src/Forms/FormHandler.php
@@ -1524,7 +1524,7 @@ class FormHandler
                 }
                 $arr_value_to_import[$field] = $this->split_ranges($value);
                 $values[$field] = "%check_array%";
-            } elseif (!empty($processed[$field]) && $row["type"] !== "CAPTCHAIMAGE") {
+            } elseif ((isset($processed[$field]) && $processed[$field] !== "") && $row["type"] !== "CAPTCHAIMAGE") {
                 $values[$field] ??= $processed[$field];
             }
         } // endforeach with reference

--- a/src/Forms/FormHandler.php
+++ b/src/Forms/FormHandler.php
@@ -1499,29 +1499,21 @@ class FormHandler
                 continue;
             }
 
-            $value = $processed[$field];
-            $check_empty = $row["check_empty"] ?? "";
-
-            if (array_key_exists("multiple", $attr) && is_array($value)) {
-                $values[$field] = (int)array_sum($value);
+            if (array_key_exists("multiple", $attr) && is_array($processed[$field])) {
+                $values[$field] = (int)array_sum($processed[$field]);
             }
-
+            
             if (!empty($row["validator"])) {
-                $result = call_user_func($row["validator"], $value);
-                $row["validation_err"] = $result;
-                if ($result !== true) {
-                    $this->all_fields_valid = false;
-                    $form_action = "ask-add";
-                    continue;
-                }
-            } elseif ($value === "") {
-                if ($check_empty === "NO-NULL") {
-                    $value = null;
-                } elseif ($check_empty === "NO") {
+                if ($processed[$field] === "" && str_starts_with($row["check_empty"] ?? "", "NO")) {
                     $row["validation_err"] = true;
-                    $this->all_fields_valid = false;
-                    $form_action = "ask-add";
-                    continue;
+                } else {
+                    $result = call_user_func($row["validator"], $processed[$field]);
+                    $row["validation_err"] = $result;
+                    if ($result !== true) {
+                        $this->all_fields_valid = false;
+                        $form_action = "ask-edit";
+                        continue;
+                    }
                 }
             }
 
@@ -1534,7 +1526,11 @@ class FormHandler
                 $arr_value_to_import[$field] = $this->split_ranges($value);
                 $values[$field] = "%check_array%";
             } elseif ($row["type"] !== "CAPTCHAIMAGE") {
-                $values[$field] ??= $value;
+                if ($processed[$field] === "" && ($row["check_empty"] ?? "") === "NO-NULL") {
+                    $values[$field] = null;
+                } else {
+                    $values[$field] ??= $processed[$field];
+                }
             }
         } // endforeach with reference
         unset ($row);


### PR DESCRIPTION
Some forms like Package Offer use indexed select lists for fields such as `packagetype` and `billingtype`, where 0 is a valid option.

Currently, these values are skipped during insert because `empty(0)` and `empty("0")` return true in PHP, causing db errors like if the field is defined as NOT NULL.

This change replaces `!empty()` with a more precise check using `isset()` and comparison against an empty string. This ensures that legitimate values such as 0 are preserved and inserted.

- Fixes insertion errors for valid forms using 0-indexed selects
- Maintains compatibility with current behavior for truly empty fields
- Improves overall robustness for form submissions with numeric values

Fixes #19 